### PR TITLE
Integrate CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.DS_Store
+.gitignore
+node_modules/
+.resources
+template/build
+template/coverage
+template/dist

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,8 @@
+tests
 lib/formatters/tsconfig.json
 lib/formatters/*.ts
+Dockerfile
 .eslintrc.json
 .prettierrc
 .resources
+.dockerignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+dist: trusty
+language: node_js
+node_js:
+  - 6
+  - 8
+  - 10
+cache:
+  yarn: true
+  directories:
+  - node_modules
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH="$HOME/.yarn/bin:$PATH"
+install: true
+script:
+  - "./tests/e2e.sh"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:8.11.3
+WORKDIR /usr/src/typescript-node-scripts
+COPY . .
+CMD ["./tests/e2e.sh"]

--- a/lib/formatForkTsCheckerMessages.js
+++ b/lib/formatForkTsCheckerMessages.js
@@ -3,7 +3,7 @@ const codeFrame = require('babel-code-frame')
 const chalk = require('chalk')
 const fs = require('fs')
 
-module.exports = (codeFrameOptions = {}) => (message, useColors) => {
+module.exports = codeFrameOptions => (message, useColors) => {
     const colors = new chalk.constructor({ enabled: useColors })
     const file = message.getFile()
     const source = file && fs.existsSync(file) && fs.readFileSync(file, 'utf-8')
@@ -11,10 +11,14 @@ module.exports = (codeFrameOptions = {}) => (message, useColors) => {
     let frame = ''
 
     if (source) {
-        frame = codeFrame(source, message.line, message.character, {
-            ...codeFrameOptions,
-            highlightCode: useColors,
-        })
+        frame = codeFrame(
+            source,
+            message.line,
+            message.character,
+            Object.assign({}, codeFrameOptions || {}, {
+                highlightCode: useColors,
+            })
+        )
             .split('\n')
             .map(str => '  ' + str.replace('|', '│'))
             .join(os.EOL)

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
         "start": "node bin/typescript-node-scripts.js start",
         "build": "node bin/typescript-node-scripts.js build",
         "initApp": "node bin/typescript-node-scripts.js create",
+        "e2e:ci": "./tests/e2e.sh",
+        "e2e:local": "docker build -t tns-docker . && docker run tns-docker",
         "precommit": "lint-staged"
     },
     "bin": {

--- a/scripts/util/createJestConfig.js
+++ b/scripts/util/createJestConfig.js
@@ -63,7 +63,7 @@ module.exports = (rootDir, srcRoots) => {
         config.rootDir = rootDir
     }
 
-    const overrides = { ...require(paths.appPackageJson).jest }
+    const overrides = Object.assign({}, require(paths.appPackageJson).jest)
     const supportedOverrides = [
         'collectCoverageFrom',
         'coverageReporters',

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# test if in docker environment
+# this script should only be running in docker!
+if [ -f /.dockerenv ]; then
+  echo "Detected script running in Docker."
+else
+  echo "ERR! This script is intended to be used inside Docker only."
+  echo "ERR! Run 'yarn e2e:local' instead."
+  exit 1
+fi
+
+# start in tests/ dir
+cd "$(dirname "$0")"
+
+TEMP_APP_PATH=`mktemp -d`
+VERDACCIO_REGISTRY_URL=http://localhost:4873
+
+function exists {
+  for f in $*; do
+    test -e "$f"
+  done
+}
+
+# exit if any command fails
+set -e
+# echo every command being executed
+set -x
+
+# go back to root directory
+cd ..
+
+# update npm
+npm i -g npm@latest
+
+# install deps
+yarn
+
+# start verdaccio
+VERDACCIO_REGISTRY_LOGS=`mktemp`
+nohup npx verdaccio@3.2.0 -c tests/verdaccio.yml &>$VERDACCIO_REGISTRY_LOGS &
+# wait for verdaccio to boot
+grep -q 'http address' <(tail -f $VERDACCIO_REGISTRY_LOGS)
+
+# set registry to verdaccio registry
+npm set registry "$VERDACCIO_REGISTRY_URL"
+yarn config set registry "$VERDACCIO_REGISTRY_URL"
+
+# login to custom registy
+(cd && npx npm-auth-to-token@1.0.0 -u user -p password -e user@example.com -r "$VERDACCIO_REGISTRY_URL")
+
+# test templates
+yarn build
+# check for local build files
+exists template/dist/*.js
+CI=true yarn test
+
+# bump version
+npm version patch
+# publish to verdaccio
+npm publish
+
+# simulate end user installs
+cd $TEMP_APP_PATH
+npx typescript-node-scripts create test-app
+
+cd test-app
+exists node_modules/typescript-node-scripts
+yarn build
+# check for build files
+exists dist/*.js
+CI=true yarn test

--- a/tests/verdaccio.yml
+++ b/tests/verdaccio.yml
@@ -1,0 +1,51 @@
+#
+# This is based on verdaccio's default config file. It allows all users
+# to do anything, so don't use it on production systems.
+#
+# Look here for more config file examples:
+# https://github.com/verdaccio/verdaccio/tree/master/conf
+#
+
+# path to a directory with all packages
+storage: ./storage
+
+auth:
+  htpasswd:
+    file: ./htpasswd
+    # Maximum amount of users allowed to register, defaults to "+inf".
+    # You can set this to -1 to disable registration.
+    #max_users: 1000
+
+# a list of other known repositories we can talk to
+uplinks:
+  npmjs:
+    url: https://registry.yarnpkg.com/
+    max_fails: 100
+    timeout: 20s
+
+packages:
+  '@*/*':
+    # scoped packages
+    access: $all
+    publish: $all
+    proxy: npmjs
+
+  '**':
+    # allow all users (including non-authenticated users) to read and
+    # publish all packages
+    #
+    # you can specify usernames/groupnames (depending on your auth plugin)
+    # and three keywords: "$all", "$anonymous", "$authenticated"
+    access: $all
+
+    # allow all known users to publish packages
+    # (anyone can register by default, remember?)
+    publish: $all
+
+    # if package is not available locally, proxy requests to 'npmjs' registry
+    proxy: npmjs
+
+# log settings
+logs:
+  - {type: stdout, format: pretty, level: http}
+  #- {type: file, path: verdaccio.log, level: info}


### PR DESCRIPTION
Set up CI test environment:
  - Running `yarn build` and `yarn test` in development
  - Publishing to custom registry, and simulating end user `npx typescript-node-scripts create <app-name>`
  - Running `yarn build` and `yarn test` in generated application