### PR TITLE
v0.4.1 - Improve tests, fix node6 support

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 lib/formatters/**/*.js
+template/**/*.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,7 @@
     "extends": "eslint:recommended",
     "parserOptions": {
         "sourceType": "module",
-        "ecmaVersion": 2018
+        "ecmaVersion": 6
     },
     "plugins": [
         "prettier"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1
+  * Improve tests
+  * Remove object spread syntax which is not supported in `node6`
+
 ## 0.4.0
   * Fix issue where ambient TypeScript files (with only type definitions) being persisted across incremental builds
     * Use `fork-ts-checker-webpack-plugin` for checking

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "typescript-node-scripts",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "Create Node.js apps based on TypeScript with zero-configuration.",
     "main": "bin/typescript-node-scripts.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "initApp": "node bin/typescript-node-scripts.js create",
         "e2e:ci": "./tests/e2e.sh",
         "e2e:local": "docker build -t tns-docker . && docker run tns-docker",
+        "lint": "eslint .",
         "precommit": "lint-staged"
     },
     "bin": {

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -49,6 +49,8 @@ yarn config set registry "$VERDACCIO_REGISTRY_URL"
 # login to custom registy
 (cd && npx npm-auth-to-token@1.0.0 -u user -p password -e user@example.com -r "$VERDACCIO_REGISTRY_URL")
 
+# lint project
+yarn lint
 # test templates
 yarn build
 # check for local build files
@@ -66,6 +68,10 @@ npx typescript-node-scripts create test-app
 
 cd test-app
 exists node_modules/typescript-node-scripts
+
+# run tslint on generated project
+yarn lint
+# build
 yarn build
 # check for build files
 exists dist/*.js


### PR DESCRIPTION
- Run `eslint` and `tslint` in CI
- `v0.4.1` fixes issue with `node6` where object spread is not supported